### PR TITLE
Investigate repository and fix bugs iteratively

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -25,7 +25,7 @@ import secrets
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
-security = HTTPBasic()
+security = HTTPBasic(auto_error=False)  # Don't auto-raise 401 if no credentials
 
 try:
     from dashboard import __version__
@@ -50,14 +50,25 @@ else:
     logger.info("✓ Authentication is ENABLED")
 
 
-def verify_credentials(credentials: HTTPBasicCredentials = Depends(security)) -> str:
+def verify_credentials(
+    credentials: Optional[HTTPBasicCredentials] = Depends(security),
+) -> str:
     """
     Verify HTTP Basic Auth credentials.
 
     Returns the username if valid, raises HTTPException if invalid.
+    If AUTH is disabled, returns 'anonymous' without requiring credentials.
     """
     if not AUTH_ENABLED:
         return "anonymous"
+
+    # If auth is enabled but no credentials provided
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+            headers={"WWW-Authenticate": "Basic"},
+        )
 
     # Use constant-time comparison to prevent timing attacks
     username_correct = secrets.compare_digest(

--- a/dashboard/tests/conftest.py
+++ b/dashboard/tests/conftest.py
@@ -1,0 +1,41 @@
+"""
+Pytest configuration for dashboard tests.
+
+This module provides fixtures and configuration for testing the dashboard
+without authentication requirements.
+"""
+
+import os
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def disable_auth():
+    """
+    Automatically disable authentication for all tests.
+
+    This fixture runs once per test session and ensures that
+    AUTH_USERNAME and AUTH_PASSWORD are cleared, allowing tests
+    to run without authentication requirements.
+    """
+    # Store original values
+    original_username = os.environ.get("AUTH_USERNAME")
+    original_password = os.environ.get("AUTH_PASSWORD")
+
+    # Clear auth environment variables BEFORE any imports
+    os.environ.pop("AUTH_USERNAME", None)
+    os.environ.pop("AUTH_PASSWORD", None)
+
+    yield
+
+    # Restore original values if they existed
+    if original_username is not None:
+        os.environ["AUTH_USERNAME"] = original_username
+    if original_password is not None:
+        os.environ["AUTH_PASSWORD"] = original_password
+
+
+# This runs at module import time, before the server module is imported
+# Clear auth variables immediately
+os.environ.pop("AUTH_USERNAME", None)
+os.environ.pop("AUTH_PASSWORD", None)

--- a/dashboard/tests/test_server.py
+++ b/dashboard/tests/test_server.py
@@ -52,13 +52,23 @@ def test_cors_enabled():
 
 
 def test_root_endpoint():
-    """Test root endpoint provides service info."""
-    from dashboard.server import app
+    """Test root endpoint provides service info or HTML dashboard."""
+    from dashboard.server import app, DASHBOARD_DIR
 
     client = TestClient(app)
     response = client.get("/")
 
     assert response.status_code == 200
-    data = response.json()
-    assert "message" in data
-    assert "version" in data
+
+    # Check if office-ui.html exists
+    html_file = DASHBOARD_DIR / "office-ui.html"
+
+    if html_file.exists():
+        # Should return HTML when file exists
+        assert response.headers["content-type"].startswith("text/html")
+        assert b"<!DOCTYPE html>" in response.content or b"<html" in response.content
+    else:
+        # Should return JSON when file doesn't exist
+        data = response.json()
+        assert "message" in data
+        assert "version" in data


### PR DESCRIPTION
Fixed two critical bugs in the dashboard test suite:

**Bug #1: Authentication in Tests (7 failing tests)**
- Changed HTTPBasic to use auto_error=False to prevent automatic 401
- Modified verify_credentials to handle Optional credentials
- Added conftest.py to disable auth in test environment
- All CEO API endpoint tests now pass without requiring credentials

**Bug #2: Root Endpoint Test (1 failing test)**
- Updated test_root_endpoint to handle both HTML and JSON responses
- Test now checks if office-ui.html exists and expects appropriate content type
- Prevents JSONDecodeError when HTML file is present

All 38 tests now pass successfully.

Changes:
- dashboard/server.py: Optional auth with auto_error=False
- dashboard/tests/conftest.py: Auto-disable auth for tests
- dashboard/tests/test_server.py: Smart HTML/JSON response handling