### PR TITLE
Improve dashboard data flow and release planning

### DIFF
--- a/dashboard/ceo_data_bridge.py
+++ b/dashboard/ceo_data_bridge.py
@@ -7,9 +7,10 @@ and the FastAPI endpoints that serve the dashboard.
 """
 
 import json
-from pathlib import Path
-from typing import List, Dict, Optional
 import logging
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,9 @@ class CEODataBridge:
     """Reads and formats CEO Discovery session data for API consumption"""
 
     def __init__(
-        self, discovery_sessions_path: str = "../.claude-flow/discovery-sessions"
+        self,
+        discovery_sessions_path: str = "../.claude-flow/discovery-sessions",
+        cache_ttl: int = 30,
     ):
         """
         Initialize the data bridge.
@@ -27,8 +30,9 @@ class CEODataBridge:
             discovery_sessions_path: Path to directory containing discovery session JSON files
         """
         self.sessions_path = Path(discovery_sessions_path)
-        self._cache = {}
-        self._cache_ttl = 30  # seconds
+        self._cache: Dict[str, object] = {}
+        self._cache_signature: Optional[Tuple[float, float]] = None
+        self._cache_ttl = cache_ttl  # seconds
 
     def get_current_session(self) -> Dict:
         """
@@ -47,9 +51,17 @@ class CEODataBridge:
                 return self._empty_session()
 
             latest_file = max(session_files, key=lambda f: f.stat().st_mtime)
+            latest_mtime = latest_file.stat().st_mtime
+
+            cached = self._use_cache(latest_mtime)
+            if cached is not None:
+                return cached
 
             with open(latest_file) as f:
                 data = json.load(f)
+
+            self._cache = data
+            self._cache_signature = (latest_mtime, time.time())
 
             return data
 
@@ -169,3 +181,18 @@ class CEODataBridge:
             "pain_points": [],
             "proposals": [],
         }
+
+    def _use_cache(self, latest_mtime: float) -> Optional[Dict]:
+        """Return cached session data if still valid for the given file mtime."""
+
+        if not self._cache or not self._cache_signature:
+            return None
+
+        cached_mtime, cached_at = self._cache_signature
+        if cached_mtime != latest_mtime:
+            return None
+
+        if time.time() - cached_at > self._cache_ttl:
+            return None
+
+        return self._cache

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -5,13 +5,15 @@ This server provides REST and WebSocket APIs for the CEO Discovery Dashboard.
 It integrates with the Becoin Economy system and supports autonomous agent operations.
 """
 
+import asyncio
+from datetime import datetime, timezone
 from fastapi import (
+    Depends,
     FastAPI,
+    HTTPException,
     Query,
     WebSocket,
     WebSocketDisconnect,
-    Depends,
-    HTTPException,
     status,
 )
 from fastapi.middleware.cors import CORSMiddleware
@@ -23,6 +25,7 @@ import logging
 import os
 import secrets
 from pathlib import Path
+import contextlib
 
 logger = logging.getLogger(__name__)
 security = HTTPBasic(auto_error=False)  # Don't auto-raise 401 if no credentials
@@ -41,6 +44,7 @@ except ModuleNotFoundError:
 AUTH_USERNAME = os.getenv("AUTH_USERNAME", "")
 AUTH_PASSWORD = os.getenv("AUTH_PASSWORD", "")
 AUTH_ENABLED = bool(AUTH_USERNAME and AUTH_PASSWORD)
+WS_POLL_INTERVAL = float(os.getenv("CEO_DASHBOARD_WS_POLL_INTERVAL", "5"))
 
 if not AUTH_ENABLED:
     logger.warning(
@@ -153,8 +157,18 @@ async def get_ceo_status(username: str = Depends(verify_credentials)):
 
 @app.get("/api/ceo/proposals")
 async def get_proposals(
-    min_roi: float = Query(0.0, description="Minimum ROI threshold"),
-    limit: int = Query(10, description="Maximum number of proposals"),
+    min_roi: float = Query(
+        0.0,
+        description="Minimum ROI threshold",
+        ge=0.0,
+        le=1000.0,
+    ),
+    limit: int = Query(
+        10,
+        description="Maximum number of proposals",
+        ge=1,
+        le=100,
+    ),
     username: str = Depends(verify_credentials),
 ):
     """Get CEO Discovery proposals with optional filtering."""
@@ -181,7 +195,12 @@ async def get_pain_points(username: str = Depends(verify_credentials)):
 
 @app.get("/api/ceo/history")
 async def get_history(
-    limit: int = Query(10, description="Maximum number of sessions to return"),
+    limit: int = Query(
+        10,
+        description="Maximum number of sessions to return",
+        ge=1,
+        le=100,
+    ),
     username: str = Depends(verify_credentials),
 ):
     """Get historical discovery sessions."""
@@ -204,23 +223,58 @@ async def websocket_endpoint(websocket: WebSocket):
     """
     await ws_manager.connect(websocket)
 
+    stream_task = asyncio.create_task(_stream_ceo_session_updates(websocket))
+
     try:
         while True:
-            # Keep connection alive and listen for any client messages
-            # (currently we only broadcast server->client, but this allows bidirectional)
-            data = await websocket.receive_text()
-            logger.info(f"Received WebSocket message: {data}")
-
-            # Echo back for debugging (can be removed in production)
-            await websocket.send_json(
-                {"type": "echo", "message": "Message received", "original": data}
-            )
+            # Keep connection alive and listen for optional client messages
+            await websocket.receive_text()
     except WebSocketDisconnect:
         ws_manager.disconnect(websocket)
         logger.info("WebSocket client disconnected normally")
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - safety net
         logger.error(f"WebSocket error: {e}")
         ws_manager.disconnect(websocket)
+    finally:
+        stream_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await stream_task
+
+
+async def _stream_ceo_session_updates(websocket: WebSocket) -> None:
+    """Continuously push CEO session snapshots to clients."""
+
+    last_signature = None
+
+    while True:
+        try:
+            session = ceo_bridge.get_current_session()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error(f"Failed to read CEO session for WebSocket: {exc}")
+            await asyncio.sleep(WS_POLL_INTERVAL)
+            continue
+
+        signature = (
+            session.get("session_id"),
+            session.get("status"),
+            len(session.get("proposals", [])),
+            len(session.get("patterns", [])),
+            len(session.get("pain_points", [])),
+        )
+
+        if signature != last_signature:
+            await websocket.send_json(
+                {
+                    "type": "session_update",
+                    "timestamp": datetime.now(timezone.utc)
+                    .isoformat()
+                    .replace("+00:00", "Z"),
+                    "session": session,
+                }
+            )
+            last_signature = signature
+
+        await asyncio.sleep(max(0.1, WS_POLL_INTERVAL))
 
 
 if __name__ == "__main__":

--- a/dashboard/tests/test_data_bridge.py
+++ b/dashboard/tests/test_data_bridge.py
@@ -122,3 +122,28 @@ def test_invalid_json():
 
         # Should fall back to empty session
         assert session["status"] == "idle"
+
+
+def test_session_cache_prevents_repeated_disk_reads(temp_discovery_dir, monkeypatch):
+    """Ensure the bridge caches the latest session for the cache TTL."""
+
+    import dashboard.ceo_data_bridge as bridge_module
+
+    bridge = bridge_module.CEODataBridge(
+        discovery_sessions_path=temp_discovery_dir, cache_ttl=60
+    )
+
+    original_load = bridge_module.json.load
+    load_count = {"calls": 0}
+
+    def tracked_load(*args, **kwargs):  # pragma: no cover - helper closure
+        load_count["calls"] += 1
+        return original_load(*args, **kwargs)
+
+    monkeypatch.setattr(bridge_module.json, "load", tracked_load)
+
+    first = bridge.get_current_session()
+    second = bridge.get_current_session()
+
+    assert first == second
+    assert load_count["calls"] == 1, "Second call should come from cache"

--- a/dashboard/tests/test_websocket.py
+++ b/dashboard/tests/test_websocket.py
@@ -44,6 +44,22 @@ def test_websocket_connection():
         assert "timestamp" in data
 
 
+def test_websocket_streams_session_updates():
+    """WebSocket should push the latest CEO session snapshot on connect."""
+
+    from dashboard.server import app
+
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws/ceo") as websocket:
+        websocket.receive_json()  # Connection established message
+        session_update = websocket.receive_json()
+
+        assert session_update["type"] == "session_update"
+        assert "session" in session_update
+        assert "timestamp" in session_update
+
+
 def test_websocket_multiple_connections():
     """Test multiple WebSocket connections"""
     from dashboard.server import app

--- a/design/UX_UI_OPTIONS.md
+++ b/design/UX_UI_OPTIONS.md
@@ -1,0 +1,44 @@
+# UX / UI Options for the CEO Discovery Dashboard
+
+The current pixel-art office UI can evolve along three complementary axes so
+that different stakeholders (CEO, COO, product squads) always see actionable
+context.
+
+## 1. Layout Modes
+1. **Command Deck (default desktop)**
+   - Left: Treasury + runway meters
+   - Center: Active projects timeline with drag-to-expand cards
+   - Right: Discovery feed (patterns, proposals, pain points)
+2. **Ops Wallboard (large displays)**
+   - Full-width grid with auto-rotating spotlight tiles showing: treasury trend,
+     top ROI proposals, orchestrator queue health, and agent availability.
+3. **Tablet Stack (field reviews)**
+   - Vertical stack of collapsible accordions with sticky KPIs so leadership can
+     approve proposals while walking the floor.
+
+## 2. Interaction Patterns
+- **Contextual approvals** – Each proposal card exposes "Approve", "Request
+  Revisions", and "Archive" buttons that emit REST calls and immediately update
+  the WebSocket feed for everyone online.
+- **Pattern drill-downs** – Clicking a pattern opens a side sheet showing root
+  cause notes, similar historical occurrences, and linked projects.
+- **Runway simulators** – Adjust burn rate sliders to preview runway impact; the
+  UI replays economy snapshots without mutating production data.
+
+## 3. Visual Language
+- **Status colors** – Use BeCoin orange for actionable, teal for healthy, and
+  muted gray for idle/queued items.
+- **Motion cues** – Subtle easing on proposal entry/exit animations keeps focus
+  without distracting from financial readouts.
+- **Accessibility** – Minimum 4.5:1 contrast, keyboard navigation for every
+  button, and ARIA live regions on WebSocket-driven notifications.
+
+## 4. Notifications & UX Copy
+- Show "Next discovery scan in <N> minutes" timer sourced from the WebSocket
+  heartbeat.
+- Use warm, human copy ("All quiet on the proposal front") when lists are empty.
+- Provide toast confirmations when executives trigger orchestrator actions so
+  they trust the automation loop.
+
+These options give design + engineering concrete hooks for iterative delivery
+without rewriting the dashboard front end.

--- a/project-management/RELEASE_TASKS.md
+++ b/project-management/RELEASE_TASKS.md
@@ -1,0 +1,56 @@
+# Release Readiness Task List
+
+This checklist translates the current simulation, dashboard, and autonomous-agent
+capabilities into release-grade requirements. Tasks are grouped so that each
+stream can be owned independently but still converge on a releasable build.
+
+## 1. Simulation Core & Treasury Safety
+- [ ] Finalize starter datasets for founders, employees, and projects so QA can
+      run deterministic smoke tests.
+- [ ] Provide a CLI entrypoint (`python -m becoin_economy.scenarios`) that seeds
+      the engine, advances time, and exports payloads for the dashboard.
+- [ ] Stress-test `advance_time` against multi-day runs (>= 10k simulated hours)
+      and persist randomized seeds that reproduce any failures.
+- [ ] Document treasury invariants (no negative balance, chronological
+      transactions, ROI sanity checks) inside `docs/` and link them from the
+      README so partners know how financial safety is enforced.
+
+## 2. Dashboard APIs & Data Bridge
+- [ ] Harden `/api/ceo/*` endpoints with structured validation errors and rate
+      limits for untrusted networks.
+- [x] Add caching to `CEODataBridge` to avoid re-reading the same discovery file
+      on every request and to smooth over short write windows.
+- [x] Stream the latest discovery session snapshot to WebSocket clients so the
+      UI updates even when no manual proposal events fire.
+- [ ] Add synthetic fixtures for status/proposal/pattern payloads and publish
+      them as part of the test suite for integrators.
+
+## 3. Dashboard UX/UI Delivery
+- [ ] Ship a single `npm run build` bundle (or equivalent) for the pixel office
+      UI and document how to deploy alongside the FastAPI service.
+- [ ] Add a responsive layout state for tablet screens and confirm at least one
+      accessibility scan (WCAG AA color contrast + focus order).
+- [ ] Provide empty/error states for each panel (treasury, proposals, patterns)
+      so leadership is never looking at a blank grid.
+
+## 4. Autonomous Execution Surface
+- [ ] Package `autonomous_agents/setup_autonomous_agents.sh` as an installable
+      Make target (`make setup-agents`) and add health checks for Ollama models.
+- [ ] Add smoke tests that spawn a dry-run orchestrator execution on CI to catch
+      plan parsing regressions early.
+- [ ] Surface orchestrator health (connected agents, queue depth, last plan)
+      through the dashboard so ops can see when autonomous work is blocked.
+
+## 5. Observability, Ops, & Security
+- [ ] Publish a `docker-compose.yml` (or Fly.io app manifest) showing how to run
+      the API, dashboard, and file watcher together with minimal env vars.
+- [ ] Pipe FastAPI access/error logs plus economy metrics into a single
+      structured log stream (e.g., OpenTelemetry / OTLP exporter).
+- [ ] Provide a secrets-management recipe (1Password/Bitwarden + `.env` templates)
+      and document the rotating credential schedule for AUTH_USERNAME/PASSWORD.
+- [ ] Define clear SLOs: dashboard median response time < 200ms, session file
+      polling within 5s, economy snapshot generation < 1s.
+
+Owning teams should update this list in their weekly cadence review. When every
+checkbox is green we have a releasable, observable product that meets the CEO's
+real-time monitoring expectations.


### PR DESCRIPTION
## Summary
- add caching to the CEO data bridge to prevent redundant file reads and document release-readiness tasks
- stream session snapshots over the WebSocket endpoint, tighten query validation, and describe UX/UI options for stakeholders
- expand the dashboard test suite to cover caching and WebSocket streaming scenarios

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691c5ef0373083228d64d332374c3845)