### PR TITLE
Add configurable CORS allowlist and tests

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -278,18 +278,17 @@ After making code changes:
 
 ### CORS
 
-Current configuration allows all origins (`allow_origins=["*"]`). For production:
+- ✅ By default the dashboard server now whitelists the local dev URLs and Fly.io domains:
+  `http://localhost:3000`, `http://127.0.0.1:3000`, `https://becoin-ecosim-llm.fly.dev`, `https://becoin-ecosystem.fly.dev`.
+- 🔒 Cookies/credentials are only sent when the origin is explicitly whitelisted.
 
-1. Edit `dashboard/server.py`
-2. Replace `allow_origins=["*"]` with specific domains:
-   ```python
-   allow_origins=[
-       "https://your-frontend.com",
-       "https://dashboard.your-company.com"
-   ]
-   ```
+Override the list via the `DASHBOARD_ALLOW_ORIGINS` environment variable (comma-separated list):
 
-3. Redeploy: `fly deploy`
+```bash
+export DASHBOARD_ALLOW_ORIGINS="https://my-dashboard.company,https://app.fly.dev"
+```
+
+Redeploy after adjusting the env var: `fly deploy`
 
 ### Recommendations
 

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -18,7 +18,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from fastapi.responses import HTMLResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
-from typing import Optional
+from typing import List, Optional
 import logging
 import os
 import secrets
@@ -100,10 +100,40 @@ ceo_bridge = CEODataBridge()
 ws_manager = WebSocketManager()
 
 # Configure CORS
+DEFAULT_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "https://becoin-ecosim-llm.fly.dev",
+    "https://becoin-ecosystem.fly.dev",
+]
+
+
+def _load_allowed_origins(env_value: Optional[str]) -> List[str]:
+    """Return the CORS allowlist based on the provided environment value."""
+
+    if env_value:
+        origins = [origin.strip() for origin in env_value.split(",") if origin.strip()]
+        if origins:
+            return origins
+    return DEFAULT_ALLOWED_ORIGINS
+
+
+ENV_ALLOWED_ORIGINS = os.getenv("DASHBOARD_ALLOW_ORIGINS")
+ALLOWED_ORIGINS = _load_allowed_origins(ENV_ALLOWED_ORIGINS)
+ALLOW_ALL_ORIGINS = "*" in ALLOWED_ORIGINS
+
+# When allow_origins includes "*", FastAPI requires allow_credentials=False to avoid
+# sending cookies/tokens to arbitrary origins. Otherwise credentials are permitted.
+if ALLOW_ALL_ORIGINS:
+    ALLOWED_ORIGINS = ["*"]
+    ALLOW_CREDENTIALS = False
+else:
+    ALLOW_CREDENTIALS = True
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, specify exact origins
-    allow_credentials=True,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=ALLOW_CREDENTIALS,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/dashboard/tests/test_server.py
+++ b/dashboard/tests/test_server.py
@@ -51,6 +51,23 @@ def test_cors_enabled():
     assert "access-control-allow-origin" in response.headers
 
 
+def test_cors_rejects_unknown_origin():
+    """Ensure preflight requests from disallowed origins are rejected."""
+    from dashboard.server import app
+
+    client = TestClient(app)
+    response = client.options(
+        "/api/status",
+        headers={
+            "Origin": "https://malicious.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code in {400, 403}
+    assert "access-control-allow-origin" not in response.headers
+
+
 def test_root_endpoint():
     """Test root endpoint provides service info or HTML dashboard."""
     from dashboard.server import app, DASHBOARD_DIR


### PR DESCRIPTION
## Summary
- restrict the dashboard CORS configuration to a curated set of known domains and allow overriding it via the `DASHBOARD_ALLOW_ORIGINS` environment variable
- disable credential sharing when a wildcard origin is used and document the new behavior in the deployment guide
- extend the server tests with a preflight integration test to ensure disallowed origins are rejected

## Testing
- pytest dashboard/tests/test_server.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691c669c0ddc832287fc4786650b3bda)